### PR TITLE
Add asset caching between snapshots

### DIFF
--- a/notionsnapshot/__main__.py
+++ b/notionsnapshot/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import urllib.parse
 import urllib.request
 import os
@@ -401,4 +402,8 @@ if __name__ == "__main__":
     file_manager = FileManager(args.url)
     driver = DriverInitializer.get_driver(args)
     soup = BeautifulSoup(driver.page_source, "html5lib")
+
+    if args.debug:
+        LOG.setLevel(logging.DEBUG)
+
     Scraper(args.url, soup, driver, file_manager, timeout=args.timeout, dark_mode=args.dark_mode).run()

--- a/notionsnapshot/__main__.py
+++ b/notionsnapshot/__main__.py
@@ -68,12 +68,12 @@ class FileManager:
             filename = hashlib.sha1(str.encode(queryless_url)).hexdigest()
             LOG.info("no filename, generated hash: " + filename)
 
-        if self.cache_assets and (cached := self._load_from_cache(filename)) is not None:
-            return cached
-
         already_downloaded = glob.glob(self.output_dir + "/assets/" + filename + ".*")
         if already_downloaded:
             return str(Path(already_downloaded[0]).relative_to(self.output_dir)).replace("\\", "/")
+
+        if self.cache_assets and (cached := self._load_from_cache(filename)) is not None:
+            return cached
 
         destination = Path(self.output_dir) / "assets" / filename
         try:

--- a/notionsnapshot/__main__.py
+++ b/notionsnapshot/__main__.py
@@ -10,7 +10,7 @@ import re
 import sys
 import uuid
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from selenium import webdriver
 from selenium.webdriver.support.wait import WebDriverWait
@@ -30,11 +30,12 @@ from argparser import ArgParser
 
 class FileManager:
     @trace()
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, cache_assets: bool = True) -> None:
         self.url = url
         id = urllib.parse.urlparse(self.url).path[1:]
         name = id[: id.rfind("-")].lower()
         self.output_dir = os.path.join("snapshots", name)
+        self.cache_assets = cache_assets
         cache_base_dir = user_cache_dir(appname="notion-snapshot", appauthor="suezli")
         self.cache_dir = os.path.join(cache_base_dir, name)
 
@@ -43,7 +44,7 @@ class FileManager:
     @trace()
     def _setup(self) -> None:
         if os.path.exists(self.output_dir):
-            if os.path.exists(self.output_dir + "/assets"):
+            if self.cache_assets and os.path.exists(self.output_dir + "/assets"):
                 LOG.info("Copying assets to caching directory")
                 shutil.copytree(self.output_dir + "/assets", self.cache_dir, dirs_exist_ok=True)
 
@@ -52,7 +53,8 @@ class FileManager:
 
         os.makedirs(self.output_dir, exist_ok=True)
         os.makedirs(self.output_dir + "/assets", exist_ok=True)
-        os.makedirs(self.cache_dir, exist_ok=True)
+        if self.cache_assets:
+            os.makedirs(self.cache_dir, exist_ok=True)
 
     @trace()
     def download_asset(self, url: str, filename: str = "") -> str:
@@ -65,12 +67,9 @@ class FileManager:
                 queryless_url = queryless_url + f"?width={params['width']}"
             filename = hashlib.sha1(str.encode(queryless_url)).hexdigest()
             LOG.info("no filename, generated hash: " + filename)
-        cache_path = os.path.join(self.cache_dir, filename + ".*")
-        cached = glob.glob(cache_path)
-        if cached:
-            LOG.debug(f"File {filename} found in cache. Using cached version")
-            shutil.copy(cached[0], self.output_dir + "/assets")
-            return os.path.join("assets", os.path.basename(cached[0]))
+
+        if self.cache_assets and (cached := self._load_from_cache(filename)) is not None:
+            return cached
 
         already_downloaded = glob.glob(self.output_dir + "/assets/" + filename + ".*")
         if already_downloaded:
@@ -105,6 +104,17 @@ class FileManager:
         except Exception as error:
             LOG.warning(f"error downloading asset on '{url}' - a hyperlink will be used in snapshot instead \n {error}")
             return str(Path(url)).replace("\\", "/")
+
+    def _load_from_cache(self, filename: str) -> Optional[str]:
+        filename = filename if Path(filename).suffix else filename + ".*"
+        cache_path = os.path.join(self.cache_dir, filename)
+        cached = glob.glob(cache_path)
+        LOG.debug("cached: " + str(cached))
+        if cached:
+            LOG.debug(f"File {filename} found in cache. Using cached version")
+            shutil.copy(cached[0], self.output_dir + "/assets")
+            return os.path.join("assets", os.path.basename(cached[0]))
+        return None
 
     @trace()
     def copy_injections_to_assets(self) -> Tuple[str, str]:
@@ -315,12 +325,13 @@ class Scraper:
                 for rule in stylesheet.cssRules:
                     if rule.type == cssutils.css.CSSRule.FONT_FACE_RULE:
                         # for some reason the url becomes https:/www.notion.so/https:/not.../<the url>
-                        url_regex = re.compile(r"url\((/?https:/www.notion.so)*(.+)\)")
+                        url_regex = re.compile(r"url\((/?https:/www.notion.so)*(.+?)\).*")
+                        LOG.debug(rule.style["src"])
                         m = url_regex.match(rule.style["src"])
                         if m is None:
                             raise ValueError("Could not parse stylesheet source of font face rule")
                         # first capture group the repeating notion url
-                        font_file = m.group(2)
+                        font_file = re.sub(r"assets/", "", m.group(2))
                         parent_css_path = os.path.split(urllib.parse.urlparse(link["href"]).path)[0]
                         LOG.debug("parent_css_path: " + parent_css_path)
                         LOG.debug("font_file: " + font_file)
@@ -423,7 +434,7 @@ class Scraper:
 
 if __name__ == "__main__":
     args = ArgParser.get_arguments()
-    file_manager = FileManager(args.url)
+    file_manager = FileManager(args.url, cache_assets=(not args.no_cache))
     driver = DriverInitializer.get_driver(args)
     soup = BeautifulSoup(driver.page_source, "html5lib")
 

--- a/notionsnapshot/argparser.py
+++ b/notionsnapshot/argparser.py
@@ -17,6 +17,7 @@ class ArgParser:
         parser.add_argument("-b", "--show-browser", help="disable headless mode and show browser window", action="store_true")
         parser.add_argument("-d", "--dark-mode", help="scrape pages in dark mode", action="store_true")
         parser.add_argument("--timeout", help="specify download timeout in seconds (default: 10s)", type=int, default=10, metavar="TIMEOUT")
+        parser.add_argument("--debug", help="enable debugging", action="store_true")
         parser.add_argument("url", help="url of the Notion page to scrape", metavar="URL")
         parser.parse_args()
         return parser.parse_args()

--- a/notionsnapshot/argparser.py
+++ b/notionsnapshot/argparser.py
@@ -18,6 +18,7 @@ class ArgParser:
         parser.add_argument("-d", "--dark-mode", help="scrape pages in dark mode", action="store_true")
         parser.add_argument("--timeout", help="specify download timeout in seconds (default: 10s)", type=int, default=10, metavar="TIMEOUT")
         parser.add_argument("--debug", help="enable debugging", action="store_true")
+        parser.add_argument("--no-cache", help="disabled asset cache", action="store_true")
         parser.add_argument("url", help="url of the Notion page to scrape", metavar="URL")
         parser.parse_args()
         return parser.parse_args()

--- a/notionsnapshot/logger.py
+++ b/notionsnapshot/logger.py
@@ -27,7 +27,7 @@ class LoggingWrapper(logging.LoggerAdapter):
     def get_log() -> logging.LoggerAdapter:
         LoggingWrapper._setup()
         logging.basicConfig(level=logging.INFO, format="%(message)s")
-        return LoggingWrapper(logging.getLogger(), {})
+        return LoggingWrapper(logging.getLogger("scrape-logger"), {})
 
     @staticmethod
     def _setup() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ cssutils = "^2.6.0"
 selenium = "^4.8.2"
 html5lib = "^1.1"
 termcolor = "^2.2.0"
+appdirs = "^1.4.4"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
- Assets are copied from old snapshots to a cache folder
- When an asset needs to be downloaded the cache is checked and matching files are copied over
- Caching is optional through a cli flag

Also includes unrelated improvements:
- App specific logger that can be configured without affecting other loggers
- A debug cli flag that sets the log level to debug for better debugging during development
- Some fixes for weird urls in the css source