### PR TITLE
Fix codec error on some notions

### DIFF
--- a/notionsnapshot/__main__.py
+++ b/notionsnapshot/__main__.py
@@ -343,9 +343,12 @@ class Scraper:
             download_path = FileManager.download_asset(f'{base_url}{link["href"]}')
 
             css_file_path = os.path.join(FileManager.output_dir, download_path)
-            with open(css_file_path, "r+") as f:
+            # Open file with UTF-8 encoding
+            with open(css_file_path, "r", encoding="utf-8") as f:
                 css_content = f.read()
 
+            # Write back with UTF-8 encoding
+            with open(css_file_path, "w", encoding="utf-8") as f:
                 url_pattern = re.compile(r"url\((https?:\/\/www\.notion\.so)?(\/[^)]+)\)")
 
                 def url_replacer(match):
@@ -359,9 +362,6 @@ class Scraper:
 
                 # Replace the URLs in the CSS content
                 modified_css_content = url_pattern.sub(url_replacer, css_content)
-
-                f.seek(0)
-                f.truncate()
                 f.write(modified_css_content)
 
             link["href"] = download_path


### PR DESCRIPTION
This PR seeks to fix the following exception

```
Traceback (most recent call last):
  File "C:\Python310\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Python310\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "C:\Users\username\notionSnapshot\notionsnapshot\__main__.py", line 512, in <module>
    Scraper().run()
  File "C:\Users\username\notionSnapshot\notionsnapshot\__main__.py", line 187, in run
    Scraper._download_stylesheets(soup)
  File "C:\Users\username\notionSnapshot\notionsnapshot\logger.py", line 63, in wrapper
    result = func(*args, **kwargs)
  File "C:\Users\username\notionSnapshot\notionsnapshot\__main__.py", line 347, in _download_stylesheets
    css_content = f.read()
  File "C:\Python310\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 14376: character maps to <undefined>
```